### PR TITLE
Fix add the missing dependencies to the SortExtenion service

### DIFF
--- a/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
+++ b/src/Bridge/Symfony/Bundle/Resources/config/elasticsearch.xml
@@ -86,6 +86,8 @@
         <service id="api_platform.elasticsearch.query_extension.sort" class="ApiPlatform\Core\Bridge\Elasticsearch\DataProvider\Extension\SortExtension" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_factory" />
             <argument type="service" id="api_platform.identifiers_extractor.cached" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
+            <argument type="service" id="api_platform.resource_class_resolver" />
             <argument>%api_platform.collection.order%</argument>
 
             <tag name="api_platform.elasticsearch.query_extension.collection" priority="10" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | N/A
| License       | MIT
| Doc PR        | N/A

Add the injection of the services `api_platform.metadata.property.metadata_factory` and `api_platform.resource_class_resolver` to the `SortExtension` constructor
